### PR TITLE
Add git action to deploy on heroku

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           cat > .env << EOF
           ARIA2C_SECRET= ${ARIA2C_SECRET}
-          RCLONE_CONFIG='${RCLONE_CONFIG}'
+          RCLONE_CONFIG="${RCLONE_CONFIG}"
           RCLONE_DESTINATION=${RCLONE_DESTINATION}
           EOF
           

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,33 @@
+# This is a basic workflow to help you get started with Actions
+name: Deploy to heroku
+
+on:
+ # push:
+#    branches:
+ #     - master
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Creat .env file
+        env: 
+          RCLONE_CONFIG: ${{ secrets.RCLONE_CONFIG }}
+          ARIA2C_SECRET: ${{ secrets.ARIA2C_SECRET }}
+          HEROKU_APP_NAME: ${{ secrets.HEROKU_APP_NAME }}
+          RCLONE_DESTINATION: ${{ secrets.RCLONE_DESTINATION }}
+        run: |
+          cat > .env << EOF
+          ARIA2C_SECRET= ${ARIA2C_SECRET}
+          RCLONE_CONFIG='${RCLONE_CONFIG}'
+          RCLONE_DESTINATION=${RCLONE_DESTINATION}
+          EOF
+          
+      - uses: akhileshns/heroku-deploy@v3.5.7 # This is the action
+        with:
+          heroku_api_key: ${{secrets.HEROKU_API_KEY}}
+          heroku_app_name: ${{secrets.HEROKU_APP_NAME}}" #Must be unique in Heroku
+          heroku_email: ${{secrets.HEROKU_EMAIL}}
+          usedocker: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,7 @@ jobs:
           RCLONE_DESTINATION=${RCLONE_DESTINATION}
           EOF
           cat .env
+          
       - uses: akhileshns/heroku-deploy@v3.6.8  # This is the action
         with:
           heroku_api_key: ${{secrets.HEROKU_API_KEY}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,8 @@ jobs:
           RCLONE_DESTINATION: ${{ secrets.RCLONE_DESTINATION }}
         run: |
           cat > .env << EOF
-          ARIA2C_SECRET= ${ARIA2C_SECRET}
+          ARIA2C_SECRET=${ARIA2C_SECRET}
+          HEROKU_APP_NAME=${HEROKU_APP_NAME}
           RCLONE_CONFIG="${RCLONE_CONFIG}"
           RCLONE_DESTINATION=${RCLONE_DESTINATION}
           EOF

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,6 @@ jobs:
       - uses: akhileshns/heroku-deploy@v3.6.8  # This is the action
         with:
           heroku_api_key: ${{secrets.HEROKU_API_KEY}}
-          heroku_app_name: ${{secrets.HEROKU_APP_NAME}}" #Must be unique in Heroku
+          heroku_app_name: ${{secrets.HEROKU_APP_NAME}} #Must be unique in Heroku
           heroku_email: ${{secrets.HEROKU_EMAIL}}
           usedocker: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
           cat > .env << EOF
           ARIA2C_SECRET=${ARIA2C_SECRET}
           HEROKU_APP_NAME=${HEROKU_APP_NAME}
-          RCLONE_CONFIG="${RCLONE_CONFIG}"
+          RCLONE_CONFIG=`${RCLONE_CONFIG}`
           RCLONE_DESTINATION=${RCLONE_DESTINATION}
           EOF
           cat .env

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
           RCLONE_DESTINATION=${RCLONE_DESTINATION}
           EOF
           cat .env
-      - uses: akhileshns/heroku-deploy@v3.5.7 # This is the action
+      - uses: akhileshns/heroku-deploy@v3.6.8  # This is the action
         with:
           heroku_api_key: ${{secrets.HEROKU_API_KEY}}
           heroku_app_name: ${{secrets.HEROKU_APP_NAME}}" #Must be unique in Heroku

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
           RCLONE_CONFIG="${RCLONE_CONFIG}"
           RCLONE_DESTINATION=${RCLONE_DESTINATION}
           EOF
-          
+          cat .env
       - uses: akhileshns/heroku-deploy@v3.5.7 # This is the action
         with:
           heroku_api_key: ${{secrets.HEROKU_API_KEY}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,4 +32,5 @@ jobs:
           heroku_api_key: ${{secrets.HEROKU_API_KEY}}
           heroku_app_name: ${{secrets.HEROKU_APP_NAME}} #Must be unique in Heroku
           heroku_email: ${{secrets.HEROKU_EMAIL}}
+          branch: master
           usedocker: true


### PR DESCRIPTION
Dear Author, 
Thanks for your great work, in order to make the deploying process more user friendly,
I added a very simple git-action workflow to deploy the app in one click without the need for CLI.

Here is the step to use this workflow:
1. Login into Heroku
2. Create an app in the Heroku web interface
3. Copy API key by going to ACCOUNT SETTING -> APL KEY
4. Fork this repository 
5. Add and fill the following secrets for the forked repository

>  ARIA2C_SECRET
>  HEROKU_APP_NAME
>  RCLONE_CONFIG
>  RCLONE_DESTINATION

e.g.

Creat ARIA2C_SECRET secrets
Fill with :
`1234`
Creat RCLONE_CONFIG secrets
Fill with :
`
type = drive\nscope = drive\ntoken = .... ...
`
6. Go to action, select Deploy to Heroku action, and run the workflow.
7. Done